### PR TITLE
refact: hashear a senha, não retorna-lo na resposta

### DIFF
--- a/src/auth/login.ts
+++ b/src/auth/login.ts
@@ -3,7 +3,7 @@ import jwt from 'jsonwebtoken'
 import { Autenticaveis } from './authEntity.js'
 
 import { AppDataSource } from '../data-source.js'
-import { decryptPassword } from '../utils/senhaUtils.js'
+import { hashPassword } from '../utils/senhaUtils.js'
 import { AppError } from '../error/ErrorHandler.js'
 
 export const login = async (req: Request, res: Response): Promise<void> => {
@@ -18,9 +18,9 @@ export const login = async (req: Request, res: Response): Promise<void> => {
     throw new AppError('Não encontrado!', 404)
   } else {
     const { id, rota, role, senha: senhaAuth } = autenticavel
-    const senhaCorrespondente = decryptPassword(senhaAuth)
+    const [ salt, hashDaSenha ] = senhaAuth.split(':')
 
-    if (senha !== senhaCorrespondente) {
+    if (hashPassword(senha, salt) !== senhaAuth) {
       throw new AppError('Senha incorreta!', 401)
     }
 

--- a/src/clinicas/clinicaController.ts
+++ b/src/clinicas/clinicaController.ts
@@ -5,7 +5,7 @@ import { Endereco } from '../enderecos/enderecoEntity.js'
 import { Especialista } from '../especialistas/EspecialistaEntity.js'
 import { mapeiaPlano } from '../utils/planoSaudeUtils.js'
 import { Clinica } from './clinicaEntity.js'
-import { encryptPassword } from '../utils/senhaUtils.js'
+import { hashPassword } from '../utils/senhaUtils.js'
 
 export const criarClinica = async (req: Request, res: Response): Promise<void> => {
   const {
@@ -15,12 +15,12 @@ export const criarClinica = async (req: Request, res: Response): Promise<void> =
     planoDeSaudeAceitos
   } = req.body
 
-  const senhaCriptografada = encryptPassword(senha)
+  const hashDaSenha = hashPassword(senha)
 
   const clinica = new Clinica()
   clinica.nome = nome
   clinica.email = email
-  clinica.senha = senhaCriptografada
+  clinica.senha = hashDaSenha
   const enderecoClinica = new Endereco()
   enderecoClinica.cep = endereco.cep
   enderecoClinica.rua = endereco.rua
@@ -37,7 +37,8 @@ export const criarClinica = async (req: Request, res: Response): Promise<void> =
   }
 
   await AppDataSource.manager.save(Clinica, clinica)
-  res.json(clinica)
+  const { senha: _senha, ...clinicaSemSenha } = clinica;
+  res.json(clinicaSemSenha)
 }
 
 export const listarClinicas = async (req: Request, res: Response): Promise<void> => {

--- a/src/especialistas/especialistaController.ts
+++ b/src/especialistas/especialistaController.ts
@@ -4,7 +4,7 @@ import { Especialista } from './EspecialistaEntity.js'
 import { mapeiaPlano } from '../utils/planoSaudeUtils.js'
 import { Endereco } from '../enderecos/enderecoEntity.js'
 import { AppError } from '../error/ErrorHandler.js'
-import { encryptPassword } from '../utils/senhaUtils.js'
+import { hashPassword } from '../utils/senhaUtils.js'
 
 // Get All
 export const especialistas = async (
@@ -30,7 +30,7 @@ export const criarEspecialista = async (
     // transforma array de numbers em array de strings com os nomes dos planos definidos no enum correspondente
     planosSaude = mapeiaPlano(planosSaude)
   }
-  const senhaCriptografada = encryptPassword(senha)
+  const hashDaSenha = hashPassword(senha)
   const especialista = new Especialista(
     nome,
     crm,
@@ -38,7 +38,7 @@ export const criarEspecialista = async (
     estaAtivo,
     especialidade,
     email,
-    telefone, possuiPlanoSaude, planosSaude, senhaCriptografada
+    telefone, possuiPlanoSaude, planosSaude, hashDaSenha
   )
 
   const enderecoPaciente = new Endereco()
@@ -59,7 +59,8 @@ export const criarEspecialista = async (
 
   try {
     await AppDataSource.manager.save(Especialista, especialista)
-    res.status(200).json(especialista)
+    const { senha: _senha, ...especialistaSemSenha } = especialista;
+    res.json(especialistaSemSenha)
   } catch (error) {
     if ((await AppDataSource.manager.findOne(Especialista, { where: { crm } })) != null) {
       res.status(422).json({ message: 'Crm já cadastrado' })

--- a/src/pacientes/pacienteController.ts
+++ b/src/pacientes/pacienteController.ts
@@ -6,7 +6,7 @@ import { CPFValido } from './validacaoCPF.js'
 import { mapeiaPlano } from '../utils/planoSaudeUtils.js'
 import { Consulta } from '../consultas/consultaEntity.js'
 import { AppError, Status } from '../error/ErrorHandler.js'
-import { encryptPassword } from '../utils/senhaUtils.js'
+import { hashPassword } from '../utils/senhaUtils.js'
 
 export const criarPaciente = async (
   req: Request,
@@ -36,12 +36,12 @@ export const criarPaciente = async (
   }
 
   try {
-    const senhaCriptografada = encryptPassword(senha)
+    const hashDaSenha = hashPassword(senha)
     const paciente = new Paciente(
       cpf,
       nome,
       email,
-      senhaCriptografada,
+      hashDaSenha,
       telefone,
       planosSaude,
       estaAtivo,
@@ -65,7 +65,8 @@ export const criarPaciente = async (
 
     await AppDataSource.manager.save(Paciente, paciente)
 
-    res.status(202).json(paciente)
+    const { senha: _senha, ...pacienteSemSenha } = paciente;
+    res.status(202).json(pacienteSemSenha)
   } catch (error) {
     res.status(502).json({ 'Paciente não foi criado': error })
   }

--- a/src/utils/senhaUtils.ts
+++ b/src/utils/senhaUtils.ts
@@ -1,24 +1,9 @@
 import crypto from 'crypto'
-// import * as dotenv from 'dotenv'
-// dotenv.config()
 
-function encryptPassword (password): string {
-  const iv = crypto.randomBytes(16)
-  const key = crypto.scryptSync(process.env.SECRET_KEY as string, 'salt', 32)
-  const cipher = crypto.createCipheriv('aes-256-cbc', key, iv)
-  let encrypted = cipher.update(password, 'utf8', 'hex')
-  encrypted += cipher.final('hex')
-  return iv.toString('hex') + ':' + encrypted
+function hashPassword (password: string, salt?: string): string {
+  salt = salt || crypto.randomBytes(16).toString('hex');
+  const hash = crypto.scryptSync(password, salt, 64).toString('hex');
+  return salt + ':' + hash;
 }
 
-function decryptPassword (encryptedPassword: string): string {
-  const [ivHex, encryptedHex] = encryptedPassword.split(':')
-  const iv = Buffer.from(ivHex, 'hex')
-  const key = crypto.scryptSync(process.env.SECRET_KEY as string, 'salt', 32)
-  const decipher = crypto.createDecipheriv('aes-256-cbc', key, iv)
-  let decrypted = decipher.update(encryptedHex, 'hex', 'utf8')
-  decrypted += decipher.final('utf8')
-  return decrypted
-}
-
-export { encryptPassword, decryptPassword }
+export { hashPassword }


### PR DESCRIPTION
Este PR atualiza 2 pontos:

1. Salvar o hash da senha é suficiente, não é necessário criptografar pois a função de hash (nesse caso o `script`) já é bem seguro.
2. Não retornar a senha na resposta para o front, nem mesmo o hash da senha.